### PR TITLE
Kategorietyp prüfen

### DIFF
--- a/lib/features/bookings/data/datasources/booking_local_data_source.dart
+++ b/lib/features/bookings/data/datasources/booking_local_data_source.dart
@@ -3,6 +3,7 @@ import 'package:moneybook/core/consts/database_consts.dart';
 import 'package:sqflite/sqflite.dart';
 
 import '../../../../core/utils/date_formatter.dart';
+import '../../../categories/domain/value_objects/categorie_type.dart';
 import '../../domain/entities/booking.dart';
 import '../../domain/value_objects/booking_type.dart';
 import '../../domain/value_objects/repetition_type.dart';
@@ -15,7 +16,7 @@ abstract class BookingLocalDataSource {
   Future<BookingModel> load(int id);
   Future<List<Booking>> loadSortedMonthly(DateTime selectedDate);
   Future<List<Booking>> loadCategorieBookings(String categorie);
-  Future<void> updateAllBookingsWithCategorie(String oldCategorie, String newCategorie);
+  Future<void> updateAllBookingsWithCategorie(String oldCategorie, String newCategorie, CategorieType categorieType);
   Future<void> updateAllBookingsWithAccount(String oldAccount, String newAccount);
 }
 
@@ -44,6 +45,7 @@ class BookingLocalDataSourceImpl implements BookingLocalDataSource {
   @override
   Future<void> edit(Booking booking) async {
     db = await openDatabase(localDbName);
+    print(booking.type.name);
     try {
       await db.rawUpdate(
           'UPDATE $bookingDbName SET id = ?, type = ?, title = ?, date = ?, repetition = ?, amount = ?, currency = ?, fromAccount = ?, toAccount = ?, categorie = ? WHERE id = ?',
@@ -129,10 +131,10 @@ class BookingLocalDataSourceImpl implements BookingLocalDataSource {
   }
 
   @override
-  Future<void> updateAllBookingsWithCategorie(String oldCategorie, String newCategorie) async {
+  Future<void> updateAllBookingsWithCategorie(String oldCategorie, String newCategorie, CategorieType categorieType) async {
     db = await openDatabase(localDbName);
-    // TODO hier weitermachen und auf Ausgabe, Einnahme oder Investitionskategorie noch zusätzlich prüfen
-    await db.rawUpdate('UPDATE $bookingDbName SET categorie = ? WHERE categorie = ?', [newCategorie, oldCategorie]);
+    await db.rawUpdate(
+        'UPDATE $bookingDbName SET categorie = ? WHERE categorie = ? AND type = ?', [newCategorie, oldCategorie, categorieType.name.trim()]);
   }
 
   @override

--- a/lib/features/bookings/data/repositories/booking_repository_impl.dart
+++ b/lib/features/bookings/data/repositories/booking_repository_impl.dart
@@ -4,6 +4,7 @@ import 'package:moneybook/core/error/failures.dart';
 import 'package:moneybook/features/bookings/data/datasources/booking_remote_data_source.dart';
 import 'package:moneybook/features/bookings/domain/entities/booking.dart';
 import 'package:moneybook/features/bookings/domain/repositories/booking_repository.dart';
+import 'package:moneybook/features/categories/domain/value_objects/categorie_type.dart';
 
 import '../datasources/booking_local_data_source.dart';
 
@@ -68,9 +69,9 @@ class BookingRepositoryImpl implements BookingRepository {
   }
 
   @override
-  Future<Either<Failure, void>> updateAllBookingsWithCategorie(String oldCategorie, String newCategorie) async {
+  Future<Either<Failure, void>> updateAllBookingsWithCategorie(String oldCategorie, String newCategorie, CategorieType categorieType) async {
     try {
-      return Right(await bookingLocalDataSource.updateAllBookingsWithCategorie(oldCategorie, newCategorie));
+      return Right(await bookingLocalDataSource.updateAllBookingsWithCategorie(oldCategorie, newCategorie, categorieType));
     } on ServerException {
       return Left(ServerFailure());
     }

--- a/lib/features/bookings/domain/repositories/booking_repository.dart
+++ b/lib/features/bookings/domain/repositories/booking_repository.dart
@@ -1,6 +1,7 @@
 import 'package:dartz/dartz.dart';
 import 'package:moneybook/core/error/failures.dart';
 import 'package:moneybook/features/bookings/domain/entities/booking.dart';
+import 'package:moneybook/features/categories/domain/value_objects/categorie_type.dart';
 
 abstract class BookingRepository {
   Future<Either<Failure, void>> create(Booking booking);
@@ -9,6 +10,6 @@ abstract class BookingRepository {
   Future<Either<Failure, Booking>> load(int id);
   Future<Either<Failure, List<Booking>>> loadSortedMonthly(DateTime selectedDate);
   Future<Either<Failure, List<Booking>>> loadCategorieBookings(String categorie);
-  Future<Either<Failure, void>> updateAllBookingsWithCategorie(String oldCategorie, String newCategorie);
+  Future<Either<Failure, void>> updateAllBookingsWithCategorie(String oldCategorie, String newCategorie, CategorieType categorieType);
   Future<Either<Failure, void>> updateAllBookingsWithAccount(String oldAccount, String newAccount);
 }

--- a/lib/features/bookings/domain/usecases/update_all_bookings_with_categorie.dart
+++ b/lib/features/bookings/domain/usecases/update_all_bookings_with_categorie.dart
@@ -4,6 +4,7 @@ import 'package:moneybook/features/bookings/domain/repositories/booking_reposito
 
 import '../../../../core/error/failures.dart';
 import '../../../../core/usecases/usecase.dart';
+import '../../../categories/domain/value_objects/categorie_type.dart';
 
 class UpdateAllBookingsWithCategorie implements UseCase<void, Params> {
   final BookingRepository bookingRepository;
@@ -12,16 +13,17 @@ class UpdateAllBookingsWithCategorie implements UseCase<void, Params> {
 
   @override
   Future<Either<Failure, void>> call(Params params) async {
-    return await bookingRepository.updateAllBookingsWithCategorie(params.oldCategorie, params.newCategorie);
+    return await bookingRepository.updateAllBookingsWithCategorie(params.oldCategorie, params.newCategorie, params.categorieType);
   }
 }
 
 class Params extends Equatable {
   final String oldCategorie;
   final String newCategorie;
+  final CategorieType categorieType;
 
-  const Params({required this.oldCategorie, required this.newCategorie});
+  const Params({required this.oldCategorie, required this.newCategorie, required this.categorieType});
 
   @override
-  List<Object> get props => [oldCategorie, newCategorie];
+  List<Object> get props => [oldCategorie, newCategorie, categorieType];
 }

--- a/lib/features/bookings/presentation/bloc/booking_bloc.dart
+++ b/lib/features/bookings/presentation/bloc/booking_bloc.dart
@@ -6,6 +6,7 @@ import 'package:moneybook/shared/presentation/widgets/arguments/bottom_nav_bar_a
 
 import '../../../../core/consts/common_consts.dart';
 import '../../../../core/consts/route_consts.dart';
+import '../../../categories/domain/value_objects/categorie_type.dart';
 import '../../domain/entities/booking.dart';
 import '../../domain/usecases/create.dart';
 import '../../domain/usecases/delete.dart';
@@ -148,8 +149,8 @@ class BookingBloc extends Bloc<BookingEvent, BookingState> {
           emit(Loaded(bookings: bookings));
         });
       } else if (event is UpdateBookingsWithCategorie) {
-        final updateAllBookingsEither =
-            await updateAllBookingsWithCategorieUseCase.bookingRepository.updateAllBookingsWithCategorie(event.oldCategorie, event.newCategorie);
+        final updateAllBookingsEither = await updateAllBookingsWithCategorieUseCase.bookingRepository
+            .updateAllBookingsWithCategorie(event.oldCategorie, event.newCategorie, event.categorieType);
         updateAllBookingsEither.fold((failure) {
           emit(const Error(message: UPDATE_ALL_BOOKINGS_FAILURE));
         }, (_) {});

--- a/lib/features/bookings/presentation/bloc/booking_event.dart
+++ b/lib/features/bookings/presentation/bloc/booking_event.dart
@@ -63,11 +63,12 @@ class LoadCategorieBookings extends BookingEvent {
 class UpdateBookingsWithCategorie extends BookingEvent {
   final String oldCategorie;
   final String newCategorie;
+  final CategorieType categorieType;
 
-  const UpdateBookingsWithCategorie(this.oldCategorie, this.newCategorie);
+  const UpdateBookingsWithCategorie(this.oldCategorie, this.newCategorie, this.categorieType);
 
   @override
-  List<Object?> get props => [oldCategorie, newCategorie];
+  List<Object?> get props => [oldCategorie, newCategorie, categorieType];
 }
 
 class UpdateBookingsWithAccount extends BookingEvent {

--- a/lib/features/budgets/data/datasources/budget_local_data_source.dart
+++ b/lib/features/budgets/data/datasources/budget_local_data_source.dart
@@ -118,7 +118,6 @@ class BudgetLocalDataSourceImpl implements BudgetLocalDataSource {
   @override
   Future<void> updateAllBudgetsWithCategorie(String oldCategorie, String newCategorie) async {
     db = await openDatabase(localDbName);
-    // TODO hier weitermachen und auf Ausgabe, Einnahme oder Investitionskategorie noch zusätzlich prüfen
     await db.rawUpdate('UPDATE $budgetDbName SET categorie = ? WHERE categorie = ?', [newCategorie, oldCategorie]);
   }
 }

--- a/lib/features/categories/presentation/pages/categorie_list_page.dart
+++ b/lib/features/categories/presentation/pages/categorie_list_page.dart
@@ -173,9 +173,6 @@ class _CategorieListPageState extends State<CategorieListPage> with TickerProvid
                                     return ChoiceChip(
                                       label: Text(CategorieType.values[index].name),
                                       selected: _selectedCategorieValue[index],
-                                      onSelected: (_) => setModalBottomState(() {
-                                        _changeCategorieType(index);
-                                      }),
                                     );
                                   },
                                 ).toList(),
@@ -223,7 +220,7 @@ class _CategorieListPageState extends State<CategorieListPage> with TickerProvid
             Categorie(
               id: categorie.id,
               type: _selectedCategorieType,
-              name: _titleController.text,
+              name: _titleController.text.trim(),
             ),
           ),
         );
@@ -237,6 +234,7 @@ class _CategorieListPageState extends State<CategorieListPage> with TickerProvid
           booking.UpdateBookingsWithCategorie(
             _oldCategorieName,
             _titleController.text,
+            _selectedCategorieType,
           ),
         );
       });


### PR DESCRIPTION
- Wenn ein Kategoriename geändert wird, wird nun zusätzlich auch der Kategorietyp geprüft, weil es vorkommen kann das es z.B. den gleichen Kategorienamen bei Einnahmen und Ausgaben geben kann (Sonstiges, etc.). So wird nun z.B. nur noch die Ausgabe Kategorie oder Einnahme Kategorie aktualisiert.
- Der Kategorietyp kann beim bearbeiten einer Kategorie nicht mehr geändert werden wird nur noch als Info dem Benutzer angezeigt.