### PR TITLE
Berechnungsbug behoben

### DIFF
--- a/lib/core/consts/common_consts.dart
+++ b/lib/core/consts/common_consts.dart
@@ -1,7 +1,11 @@
 const bool adminMode = true;
 const String locale = 'de-DE';
 const String singleLocale = 'de';
-const String currency = '€';
+const String currencyLocale = '€';
+
+// Anmerkung: \ bei $ wird benötigt, weil $ ein spezieller Character in Dart ist und
+// normalerweise für String interpolation (z.B.: "$variable") verwendet wird.
+const List<String> currencySymbols = ['€', '\$'];
 
 const int durationInMs = 800;
 const int animationDurationInMs = 650;

--- a/lib/core/consts/regex_consts.dart
+++ b/lib/core/consts/regex_consts.dart
@@ -2,3 +2,6 @@
 // Negative Beträge sind ebenfalls erlaubt z.B. -8,50 €,
 // dabei ist das Minus nur an der ersten Position erlaubt.
 final moneyRegex = RegExp(r'^-?$|^-?\d+(,\d{0,2})?$');
+
+// Regex gibt String mit nur Zahlen, Kommas und Punkten zurück z.B.: Von 8,65 € auf 8.65
+final numberRegex = RegExp(r'[^0-9.,]');

--- a/lib/features/bookings/domain/value_objects/amount.dart
+++ b/lib/features/bookings/domain/value_objects/amount.dart
@@ -1,3 +1,7 @@
+import 'package:moneybook/core/consts/regex_consts.dart';
+
+import '../../../../core/consts/common_consts.dart';
+
 class Amount {
   final double value;
   final String currency;
@@ -7,11 +11,27 @@ class Amount {
     required this.currency,
   });
 
+  // Beispiel:
+  // Input amount: 8,60 €
+  // Es werden alle nicht Zahlen, Kommas und Punkte vom String entfernt.
+  // Anschließend werden Kommas (,) durch Punkte (.) ersetzt.
+  // return 8.6
   static double getValue(String amount) {
-    return double.parse(amount.substring(0, amount.length - 2).replaceAll('.', '').replaceAll(',', '.'));
+    String cleanedAmount = amount.replaceAll(numberRegex, '');
+    cleanedAmount = cleanedAmount.replaceAll('.', '').replaceAll(',', '.');
+    return double.parse(cleanedAmount);
   }
 
+  // Beispiel:
+  // Input amount: 8,60 € oder $8.60
+  // Der String wird nach einem gültigen currencySymbol durchsucht (€, $, etc.) und zurückgegeben
+  // return € oder $
   static String getCurrency(String amount) {
-    return amount.substring(amount.length - 1, amount.length);
+    for (String currencySymbol in currencySymbols) {
+      if (amount.contains(currencySymbol)) {
+        return currencySymbol;
+      }
+    }
+    return currencyLocale;
   }
 }

--- a/lib/features/bookings/presentation/pages/edit_booking_page.dart
+++ b/lib/features/bookings/presentation/pages/edit_booking_page.dart
@@ -88,7 +88,7 @@ class _EditBookingPageState extends State<EditBookingPage> {
       title: widget.booking.title,
       date: widget.booking.date,
       repetition: widget.booking.repetition,
-      amount: Amount.getValue(widget.booking.amount.toString()),
+      amount: widget.booking.amount,
       amountType: widget.booking.amountType,
       currency: Amount.getCurrency(widget.booking.amount.toString()),
       fromAccount: widget.booking.fromAccount,
@@ -144,7 +144,7 @@ class _EditBookingPageState extends State<EditBookingPage> {
   // Alte Buchung zuerst rückgängig machen...
   Future<void> _reverseBooking() async {
     if (_oldBooking.type == BookingType.expense) {
-      print(_oldBooking.amount);
+      print('Test: ${_oldBooking.amount}');
       BlocProvider.of<AccountBloc>(context).add(AccountDeposit(_oldBooking, 0));
     } else if (_oldBooking.type == BookingType.income) {
       BlocProvider.of<AccountBloc>(context).add(AccountWithdraw(_oldBooking, 0));

--- a/lib/shared/presentation/widgets/bottom_sheets/amount_bottom_sheet.dart
+++ b/lib/shared/presentation/widgets/bottom_sheets/amount_bottom_sheet.dart
@@ -72,7 +72,7 @@ void openBottomSheetForAmountInput({required BuildContext context, required Text
   ).whenComplete(() {
     if (amountController.text == '-') {
       amountController.text = '';
-    } else if (amountController.text.isNotEmpty && !amountController.text.contains(currency)) {
+    } else if (amountController.text.isNotEmpty && !amountController.text.contains(currencyLocale)) {
       amountController.text = formatToMoneyAmount(amountController.text, withoutDecimalPlaces: -1);
     }
   });


### PR DESCRIPTION
- Beim Bearbeiten von Buchungen wurden bei Kommazahlen die Werte falsch berechnet, weil die Nachkommastellen entfernt wurden. Dies wurde behoben und die entsprechenden Funktionen verbessert. Die Werte werden wieder richtig berechnet.