### PR TITLE
77 feedback board einbinden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .svn/
 migrate_working_dir/
 private/
+lib/core/github/github_config.dart
 **/build.gradle
 key.jks
 

--- a/lib/core/consts/route_consts.dart
+++ b/lib/core/consts/route_consts.dart
@@ -14,3 +14,5 @@ const settingsRoute = 'settings';
 const aboveRoute = 'above';
 const impressumRoute = 'impressum';
 const creditRoute = 'credit';
+const feedbackRoute = 'feedback';
+const bugReportRoute = 'bugReport';

--- a/lib/core/github/github_functions.dart
+++ b/lib/core/github/github_functions.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+
+import 'package:flutter/cupertino.dart';
+import 'package:http/http.dart' as http;
+
+import 'github_config.dart';
+
+class GithubApi {
+  Future<bool> createGitHubIssue(
+      {required GlobalKey<FormState> formKey,
+      required String title,
+      required String description,
+      required String milestoneTitle,
+      List<String> labels = const []}) async {
+    final FormState form = formKey.currentState!;
+    if (form.validate() == false) {
+      return false;
+    } else {
+      int? milestoneId = await _getMilestoneId(milestoneTitle);
+      if (milestoneId == null) {
+        print("Meilenstein: $milestoneTitle wurde nicht gefunden!");
+        return false;
+      }
+
+      final Uri url = Uri.parse("${githubRootPath}/repos/${githubOwner}/${githubRepo}/issues");
+      final response = await http.post(
+        url,
+        headers: {
+          "Authorization": "Bearer ${githubToken}",
+          "Accept": "application/vnd.github.v3+json",
+          "Content-Type": "application/json",
+        },
+        body: jsonEncode({
+          "title": title,
+          "body": description,
+          "milestone": milestoneId,
+          "labels": labels,
+        }),
+      );
+
+      if (response.statusCode == 201) {
+        print("Issue erfolgreich erstellt!");
+        return true;
+      } else {
+        print("Fehler: ${response.statusCode} - ${response.body}");
+        return false;
+      }
+    }
+  }
+
+  Future<int?> _getMilestoneId(String milestoneTitle) async {
+    final Uri url = Uri.parse("${githubRootPath}/repos/${githubOwner}/${githubRepo}/milestones");
+
+    final githubResponse = await http.get(
+      url,
+      headers: {
+        "Authorization": "Bearer ${githubToken}",
+        "Accept": "application/vnd.github.v3+json",
+      },
+    );
+
+    if (githubResponse.statusCode == 200) {
+      List<dynamic> milestones = jsonDecode(githubResponse.body);
+      for (var milestone in milestones) {
+        if (milestone['title'] == milestoneTitle) {
+          return milestone['number']; // GitHub verwendet "number" als ID
+        }
+      }
+    } else {
+      print("Fehler beim Abrufen der Meilensteine von Github: ${githubResponse.statusCode}");
+    }
+    return null;
+  }
+}

--- a/lib/features/settings/presentation/pages/bug_report_page.dart
+++ b/lib/features/settings/presentation/pages/bug_report_page.dart
@@ -1,0 +1,98 @@
+import 'dart:async';
+
+import 'package:another_flushbar/flushbar.dart';
+import 'package:flutter/material.dart';
+import 'package:moneybook/core/consts/common_consts.dart';
+import 'package:moneybook/shared/presentation/widgets/buttons/save_button.dart';
+import 'package:moneybook/shared/presentation/widgets/input_fields/long_description_text_field.dart';
+import 'package:rounded_loading_button_plus/rounded_loading_button.dart';
+
+import '../../../../core/github/github_functions.dart';
+import '../../../../shared/presentation/widgets/input_fields/title_text_field.dart';
+
+class BugReportPage extends StatefulWidget {
+  const BugReportPage({super.key});
+
+  @override
+  State<BugReportPage> createState() => _BugReportPageState();
+}
+
+class _BugReportPageState extends State<BugReportPage> {
+  final GlobalKey<FormState> _bugReportFormKey = GlobalKey<FormState>();
+  TextEditingController titleController = TextEditingController();
+  TextEditingController descriptionController = TextEditingController();
+  final RoundedLoadingButtonController _sendBugReportBtnController = RoundedLoadingButtonController();
+
+  Future<void> createBugReportIssue() async {
+    GithubApi github = GithubApi();
+    bool successful = await github.createGitHubIssue(
+        formKey: _bugReportFormKey,
+        title: titleController.text,
+        description: descriptionController.text,
+        milestoneTitle: "User: Bug Report",
+        labels: ["bug"]);
+    if (successful == false) {
+      _sendBugReportBtnController.error();
+      Timer(const Duration(milliseconds: durationInMs), () {
+        _sendBugReportBtnController.reset();
+      });
+      return;
+    }
+    _sendBugReportBtnController.success();
+    Flushbar(
+      message: "Vielen Dank für das Senden deiner Fehlermeldung.",
+      icon: Icon(
+        Icons.done_rounded,
+        size: 28.0,
+        color: Colors.greenAccent,
+      ),
+      duration: Duration(milliseconds: 2500),
+      leftBarIndicatorColor: Colors.greenAccent,
+      flushbarPosition: FlushbarPosition.TOP,
+      shouldIconPulse: false,
+    )..show(context);
+    await Future.delayed(Duration(milliseconds: 2500));
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Fehler melden'),
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 16.0),
+          child: Card(
+            child: Form(
+              key: _bugReportFormKey,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 12.0),
+                    child: TitleTextField(
+                      hintText: 'Titel...',
+                      titleController: titleController,
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(12.0, 16.0, 12.0, 0.0),
+                    child: LongDescriptionTextField(
+                      hintText:
+                          'Bitte geben Sie eine detaillierte Fehlerbeschreibung an, damit wir das Problem bestmöglich analysieren und schnellstmöglich beheben können.',
+                      descriptionController: descriptionController,
+                    ),
+                  ),
+                  SaveButton(text: 'Senden', saveBtnController: _sendBugReportBtnController, onPressed: () => createBugReportIssue()),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/presentation/pages/feedback_page.dart
+++ b/lib/features/settings/presentation/pages/feedback_page.dart
@@ -59,7 +59,7 @@ class _FeedbackPageState extends State<FeedbackPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Feedback geben'),
+        title: Text('Feedback einreichen'),
       ),
       body: SingleChildScrollView(
         child: Padding(
@@ -81,7 +81,8 @@ class _FeedbackPageState extends State<FeedbackPage> {
                   Padding(
                     padding: const EdgeInsets.fromLTRB(12.0, 16.0, 12.0, 0.0),
                     child: LongDescriptionTextField(
-                      hintText: 'Feedback, Ideen für ein neues Feature, andere Vorschläge, ...',
+                      hintText:
+                          'Teile dein Feedback mit dem Entwickler, um Moneybook zu verbessern. Feedback, Ideen für ein neues Feature, andere Vorschläge, ...',
                       descriptionController: descriptionController,
                     ),
                   ),

--- a/lib/features/settings/presentation/pages/feedback_page.dart
+++ b/lib/features/settings/presentation/pages/feedback_page.dart
@@ -1,0 +1,97 @@
+import 'dart:async';
+
+import 'package:another_flushbar/flushbar.dart';
+import 'package:flutter/material.dart';
+import 'package:moneybook/core/consts/common_consts.dart';
+import 'package:moneybook/core/github/github_functions.dart';
+import 'package:moneybook/shared/presentation/widgets/buttons/save_button.dart';
+import 'package:moneybook/shared/presentation/widgets/input_fields/long_description_text_field.dart';
+import 'package:rounded_loading_button_plus/rounded_loading_button.dart';
+
+import '../../../../shared/presentation/widgets/input_fields/title_text_field.dart';
+
+class FeedbackPage extends StatefulWidget {
+  const FeedbackPage({super.key});
+
+  @override
+  State<FeedbackPage> createState() => _FeedbackPageState();
+}
+
+class _FeedbackPageState extends State<FeedbackPage> {
+  final GlobalKey<FormState> _feedbackFormKey = GlobalKey<FormState>();
+  TextEditingController titleController = TextEditingController();
+  TextEditingController descriptionController = TextEditingController();
+  final RoundedLoadingButtonController _sendFeedbackBtnController = RoundedLoadingButtonController();
+
+  Future<void> createFeedbackIssue() async {
+    GithubApi github = GithubApi();
+    bool successful = await github.createGitHubIssue(
+        formKey: _feedbackFormKey,
+        title: titleController.text,
+        description: descriptionController.text,
+        milestoneTitle: "User: Feedback",
+        labels: ["feedback"]);
+    if (successful == false) {
+      _sendFeedbackBtnController.error();
+      Timer(const Duration(milliseconds: durationInMs), () {
+        _sendFeedbackBtnController.reset();
+      });
+      return;
+    }
+    _sendFeedbackBtnController.success();
+    Flushbar(
+      message: "Vielen Dank. Dein Feedback wurde erfolgreich gesendet.",
+      icon: Icon(
+        Icons.done_rounded,
+        size: 28.0,
+        color: Colors.greenAccent,
+      ),
+      duration: Duration(milliseconds: 2500),
+      leftBarIndicatorColor: Colors.greenAccent,
+      flushbarPosition: FlushbarPosition.TOP,
+      shouldIconPulse: false,
+    )..show(context);
+    await Future.delayed(Duration(milliseconds: 2500));
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Feedback geben'),
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 16.0),
+          child: Card(
+            child: Form(
+              key: _feedbackFormKey,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 12.0),
+                    child: TitleTextField(
+                      hintText: 'Titel...',
+                      titleController: titleController,
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(12.0, 16.0, 12.0, 0.0),
+                    child: LongDescriptionTextField(
+                      hintText: 'Feedback, Ideen für ein neues Feature, andere Vorschläge, ...',
+                      descriptionController: descriptionController,
+                    ),
+                  ),
+                  SaveButton(text: 'Senden', saveBtnController: _sendFeedbackBtnController, onPressed: () => createFeedbackIssue()),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,6 +30,8 @@ import 'features/budgets/presentation/pages/create_budget_page.dart';
 import 'features/budgets/presentation/pages/edit_budget_page.dart';
 import 'features/budgets/presentation/widgets/page_arguments/edit_budget_page_arguments.dart';
 import 'features/categories/presentation/bloc/categorie_bloc.dart';
+import 'features/settings/presentation/pages/bug_report_page.dart';
+import 'features/settings/presentation/pages/feedback_page.dart';
 import 'features/settings/presentation/pages/impressum_page.dart';
 import 'features/statistics/presentation/bloc/categorie_stats_bloc.dart';
 import 'features/user/presentation/bloc/user_bloc.dart';
@@ -98,6 +100,8 @@ class MyApp extends StatelessWidget {
         aboveRoute: (context) => const AbovePage(),
         impressumRoute: (context) => const ImpressumPage(),
         creditRoute: (context) => const CreditPage(),
+        feedbackRoute: (context) => const FeedbackPage(),
+        bugReportRoute: (context) => const BugReportPage(),
       },
       onGenerateRoute: (RouteSettings settings) {
         switch (settings.name) {

--- a/lib/shared/presentation/widgets/deco/new_label.dart
+++ b/lib/shared/presentation/widgets/deco/new_label.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class NewLabel extends StatelessWidget {
+  const NewLabel({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12.0),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 3.0),
+        decoration: BoxDecoration(
+          border: Border.all(color: Colors.cyanAccent.shade400, width: 0.7),
+          borderRadius: BorderRadius.circular(7.0),
+        ),
+        child: Text(
+          'Neu',
+          style: TextStyle(fontSize: 10.0, color: Colors.cyanAccent.shade400, fontWeight: FontWeight.bold),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/presentation/widgets/input_fields/long_description_text_field.dart
+++ b/lib/shared/presentation/widgets/input_fields/long_description_text_field.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+class LongDescriptionTextField extends StatelessWidget {
+  final String hintText;
+  final TextEditingController descriptionController;
+  final int maxLength;
+  final int maxLines;
+  final bool autofocus;
+  final FocusNode focusNode = FocusNode();
+
+  LongDescriptionTextField({
+    super.key,
+    required this.hintText,
+    required this.descriptionController,
+    this.maxLength = 1000,
+    this.maxLines = 7,
+    this.autofocus = false,
+  });
+
+  String? _checkTextInput() {
+    if (descriptionController.text.isEmpty) {
+      return 'Bitte geben Sie eine Beschreibung ein.';
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: descriptionController,
+      maxLength: maxLength,
+      maxLines: maxLines,
+      autofocus: autofocus,
+      focusNode: focusNode,
+      textAlignVertical: TextAlignVertical.center,
+      textCapitalization: TextCapitalization.sentences,
+      validator: (input) => _checkTextInput(),
+      decoration: InputDecoration(
+        hintText: hintText,
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(10.0),
+          borderSide: BorderSide(color: Colors.grey, width: 1.0),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(10.0),
+          borderSide: BorderSide(color: Colors.cyanAccent, width: 1.5),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/presentation/widgets/navigation_widgets/side_menu_drawer_widget.dart
+++ b/lib/shared/presentation/widgets/navigation_widgets/side_menu_drawer_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/consts/route_consts.dart';
+import '../deco/new_label.dart';
 
 class SideMenuDrawer extends StatefulWidget {
   final int tabIndex;
@@ -148,9 +149,14 @@ class _SideMenuDrawerState extends State<SideMenuDrawer> {
               Icons.rate_review_rounded,
               color: widget.tabIndex == 5 ? Colors.cyan.shade400 : Colors.white,
             ),
-            title: Text(
-              'Feedback geben',
-              style: TextStyle(color: widget.tabIndex == 5 ? Colors.cyan.shade400 : Colors.white),
+            title: Row(
+              children: [
+                Text(
+                  'Feedback',
+                  style: TextStyle(color: widget.tabIndex == 5 ? Colors.cyan.shade400 : Colors.white),
+                ),
+                NewLabel(),
+              ],
             ),
             trailing: Icon(
               Icons.keyboard_arrow_right_rounded,
@@ -166,9 +172,14 @@ class _SideMenuDrawerState extends State<SideMenuDrawer> {
               Icons.bug_report_rounded,
               color: widget.tabIndex == 6 ? Colors.cyan.shade400 : Colors.white,
             ),
-            title: Text(
-              'Fehler melden',
-              style: TextStyle(color: widget.tabIndex == 6 ? Colors.cyan.shade400 : Colors.white),
+            title: Row(
+              children: [
+                Text(
+                  'Fehler melden',
+                  style: TextStyle(color: widget.tabIndex == 6 ? Colors.cyan.shade400 : Colors.white),
+                ),
+                NewLabel(),
+              ],
             ),
             trailing: Icon(
               Icons.keyboard_arrow_right_rounded,

--- a/lib/shared/presentation/widgets/navigation_widgets/side_menu_drawer_widget.dart
+++ b/lib/shared/presentation/widgets/navigation_widgets/side_menu_drawer_widget.dart
@@ -145,11 +145,11 @@ class _SideMenuDrawerState extends State<SideMenuDrawer> {
           const Divider(),
           ListTile(
             leading: Icon(
-              Icons.settings_rounded,
+              Icons.rate_review_rounded,
               color: widget.tabIndex == 5 ? Colors.cyan.shade400 : Colors.white,
             ),
             title: Text(
-              'Einstellungen',
+              'Feedback geben',
               style: TextStyle(color: widget.tabIndex == 5 ? Colors.cyan.shade400 : Colors.white),
             ),
             trailing: Icon(
@@ -157,6 +157,43 @@ class _SideMenuDrawerState extends State<SideMenuDrawer> {
               color: widget.tabIndex == 5 ? Colors.cyan.shade400 : Colors.white,
             ),
             selected: widget.tabIndex == 5,
+            onTap: () {
+              Navigator.popAndPushNamed(context, feedbackRoute);
+            },
+          ),
+          ListTile(
+            leading: Icon(
+              Icons.bug_report_rounded,
+              color: widget.tabIndex == 6 ? Colors.cyan.shade400 : Colors.white,
+            ),
+            title: Text(
+              'Fehler melden',
+              style: TextStyle(color: widget.tabIndex == 6 ? Colors.cyan.shade400 : Colors.white),
+            ),
+            trailing: Icon(
+              Icons.keyboard_arrow_right_rounded,
+              color: widget.tabIndex == 6 ? Colors.cyan.shade400 : Colors.white,
+            ),
+            selected: widget.tabIndex == 6,
+            onTap: () {
+              Navigator.popAndPushNamed(context, bugReportRoute);
+            },
+          ),
+          const Divider(),
+          ListTile(
+            leading: Icon(
+              Icons.settings_rounded,
+              color: widget.tabIndex == 7 ? Colors.cyan.shade400 : Colors.white,
+            ),
+            title: Text(
+              'Einstellungen',
+              style: TextStyle(color: widget.tabIndex == 7 ? Colors.cyan.shade400 : Colors.white),
+            ),
+            trailing: Icon(
+              Icons.keyboard_arrow_right_rounded,
+              color: widget.tabIndex == 7 ? Colors.cyan.shade400 : Colors.white,
+            ),
+            selected: widget.tabIndex == 7,
             onTap: () {
               Navigator.popAndPushNamed(context, settingsRoute);
             },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -318,13 +318,13 @@ packages:
     source: hosted
     version: "2.1.2"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
-      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.0"
   http_multi_server:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   flutter_settings_ui: ^3.0.1
   package_info_plus: ^4.0.0
   lottie: ^3.1.3
+  http: ^1.3.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
- Feedback einreichen auf eigener Seite implementiert und mit Github Meilenstein User: Feedback verknüpft.
- Fehler melden auf eigener Seite implementiert und mit Github Meilenstein User: Bug Report verknüpft.
- Erste kleine Github API Funktion + Konfigparameter bereitgestellt, um Issues zu erstellen (mit Meilenstein Zuordnung und Labels).
- "Neu Label" hinzugefügt, um Benutzern neue Features ersichtlicher zu machen.
- Oben beschriebene Features zu Sidebar hinzugefügt, wo sie für den Benutzer aufrufbar und benutzbar sind.