### PR TITLE
Neue Buchungen Bugfix

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: "A new Flutter project."
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.1.2
+version: 1.1.4
 
 environment:
   sdk: '>=3.3.4 <4.0.0'


### PR DESCRIPTION
- Neue Buchungen werden nun erst als gebucht markiert, wenn die Buchung auf ein Konto gebucht wurde - in Transaktion eingefügt.
- Es wird nur noch auf das Datum (YYYY-MM-DD) geprüft nicht mehr auf die Uhrzeit.